### PR TITLE
[WIP] A theory that you can use indexedDB to free memory

### DIFF
--- a/example.html
+++ b/example.html
@@ -45,6 +45,7 @@
 	<script src="StreamSaver.js"></script>
 	<script src="https://cdn.jsdelivr.net/webtorrent/latest/webtorrent.min.js"></script>
 	<script src="https://rawgit.com/jimmywarting/browser-su/master/build/permissions.js"></script>
+	<script src="https://cdn.rawgit.com/eligrey/FileSaver.js/master/FileSaver.min.js"></script>
 	<script src="https://cdn.rawgit.com/creatorrr/web-streams-polyfill/68f93d7240d925d27b175ce39133f57993c3f109/dist/polyfill.min.js"
 		integrity="sha384-wC6EeO3kVv23JQA/XjoEHMvxOwXZXIRdxvhOt8rOcoGPYQnPbumUJugHHoJAdM0x"
 		crossorigin
@@ -95,16 +96,17 @@
 
 					$ipsum.onclick = event => {
 						let text = encoder.encode((Lorem + "\n\n").repeat(2*1024)) // 1 MiB
-						let n = ~~prompt("How many MiB of lorem ipsum text do you want?", '1024')
-						// n *= 1024
-						let que = Promise.resolve()
-						let pump = () => {
-							n-- && que.then(() => {
-								myFile.write(text).then(()=>{setTimeout(pump)})
-								// myFile.write(text).then(()=>pump()) // This should be possible
-							})
-						}
-						pump()
+						let res = prompt('How many MiB of lorem ipsum text do you want?\nWarning: Will evil()', '512 * 2 // 1 GiB')
+
+						let n = eval(res)
+						// Oh I'm so evil :P
+						// You only have yourself to blame!
+						// Nothing here that can be exposed... So
+
+						let pump = () => n-- && myFile.write(text).then(pump)
+						console.time('lorem ipsum')
+						pump().then(() => console.timeEnd('lorem ipsum'))
+
 					}
 
 				break; case "video":


### PR DESCRIPTION
Background
=========
After reading this: 
> The file and blob parts of new blobs are just references. When we create new blobs we only need to transport the new memory - [goo.gl/EtROPm](goo.gl/EtROPm)

And previusly trying a simple thing as merging two big files from the computer with just a file input with a success
```javascript
new blob([big_file_A_from_disk, big_file_B_from_disk])
```
Says that the new Blob doesn't take up any memory

And also reading this [Stackoverflow question](http://stackoverflow.com/questions/39253244/large-blob-file-in-javascript/39257212?noredirect=1#comment65850553_39257212) - Gave me a idea that you can move a blob from memory to the disk using the indexedDB

This should work in theory but I would like a second opinion and get help reviewing this code, testing performance and memory - This is currently only done with firefox in mind since they have a temporary storage (follows a unofficial `indexedDB.open()` api)

What has changed?
==============
I have temporary disabled the service worker and gone to creating the final large blob in the browser instead with fragments from the disk using the indexedDB as a solution to move some stuff from the memory to the disk

When the stream closes it will merge all fragments into one big Blob

Further ideas
==========

I have an idea that I could write a util function like `revokeBlob(new Blob(['memory blob']))` that return a new blob that comes from the disk instead - this will delete the file from the indexedDB instantly but also return it. Then it could be possible to avoid the quotaExceeded error (that was 2 gb on my machine)

@all, @vobruba-martin @eligrey 