### PR TITLE
Filename should be enclosed with quotation marks.

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -58,7 +58,7 @@ function hijacke(uniqLink, stream, data, port){
 
 	headers = {
 		'Content-Type': 'application/octet-stream; charset=utf-8',
-		'Content-Disposition': 'attachment; filename=' + (filename || data.filename)
+		'Content-Disposition': 'attachment; filename="' + (filename || data.filename) + '"'
 	}
 
 	if(data.size)


### PR DESCRIPTION
For example if you have a comma in your filename then browser will not
be able to fully read it.