### PR TITLE
Safari already has streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Supported browsers
 | Opera 39+  | Yes       |                         |
 | Chrome 52+ | Yes       |                         |
 | Firefox    | No        | Streams                 |
-| Safari     | No        | Streams, SW             |
+| Safari     | No        | SW                      |
 | Edge       | No        | Streams, SW             |
 | IE         | No        | Everything (IE is dead) |
 


### PR DESCRIPTION
Just found that stable safari (10.1) has both `ReadableSteam` and `WritableStream` without any flags:

![screen shot 2017-04-23 at 15 39 40 2](https://cloud.githubusercontent.com/assets/2605831/25312169/b869ef46-283c-11e7-8dc3-e7d9f56b2e4a.png)
