### PR TITLE
Add check for service worker in Saver.supported

### DIFF
--- a/StreamSaver.js
+++ b/StreamSaver.js
@@ -22,7 +22,7 @@
 
 	try {
 		// Some browser has it but ain't allowed to construct a stream yet
-		streamSaver.supported = !!new ReadableStream()
+		streamSaver.supported = !!new ReadableStream() && navigator.serviceWorker
 	} catch(err) {
 		// if you are running chrome < 52 then you can enable it
 		// `chrome://flags/#enable-experimental-web-platform-features`


### PR DESCRIPTION
Add a check in `streamSaver.supported` for `serviceWorker`. Before it `streamSaver.supported` in Safari returns `true` but it is't working without `serviceWorker`.