### PR TITLE
Call getWriter() and use result so example mp4 will stream.

### DIFF
--- a/example.html
+++ b/example.html
@@ -120,14 +120,16 @@
 				case "fetch":
 					// Here we could just simply open the link and then let
 					// the SW add Content-Disposition header to that request.
+					let myFile = streamSaver.createWriteStream(filename)
+					let writer = myFile.getWriter()
 					fetch(url).then(res => {
 						// https://jakearchibald.com/2016/streams-ftw/
 						// The body is a stream :)
 						let reader = res.body.getReader()
 						let pump = () => reader.read()
 							.then(res => res.done
-								? myFile.close()
-								: myFile.write(res.value).then(pump))
+								? writer.close()
+								: writer.write(res.value).then(pump))
 
 						pump()
 					})


### PR DESCRIPTION
Prior to this was seeing ,```example.html:130 Uncaught (in promise) ReferenceError: myFile is not defined at reader.read.then.res```