### PR TITLE
Replace references to myFile with writer so Fetch stream example works.

### DIFF
--- a/example.html
+++ b/example.html
@@ -126,8 +126,8 @@
 						let reader = res.body.getReader()
 						let pump = () => reader.read()
 							.then(res => res.done
-								? myFile.close()
-								: myFile.write(res.value).then(pump))
+								? writer.close()
+								: writer.write(res.value).then(pump))
 
 						pump()
 					})


### PR DESCRIPTION
Prior to this was seeing, ```example.html:130 Uncaught (in promise) ReferenceError: myFile is not defined at reader.read.then.res```.