### PR TITLE
Prevent ServiceWorker timeout on Firefox

### DIFF
--- a/mitm.html
+++ b/mitm.html
@@ -23,7 +23,7 @@ let keepAlive = sw => {
   keepAlive = () => {}
   setInterval(() => {
     sw.postMessage('ping', [new MessageChannel().port2])
-  }, 27E4) // 4.5min
+  }, 29E3) // 29sec
 }
 
 // message event is the first thing we need to setup a listner for


### PR DESCRIPTION
Ping the ServiceWorker every 29 seconds to prevent Firefox's 30 seconds timeout