### PR TITLE
Add support for Web Extensions on Google Chrome

### DIFF
--- a/StreamSaver.js
+++ b/StreamSaver.js
@@ -8,7 +8,9 @@
 })('streamSaver', () => {
   'use strict'
 
-  const secure = location.protocol === 'https:' || location.hostname === 'localhost'
+  const secure = location.protocol === 'https:' ||
+                 location.protocol === 'chrome-extension:' ||
+                 location.hostname === 'localhost'
   let iframe
   let loaded
   let transfarableSupport = false
@@ -65,7 +67,13 @@
         if (evt.data.download) {
           resolve() // Signal that the writestream are ready to recive data
           if (!secure) popup.close() // don't need the popup any longer
-          window.location = evt.data.download
+          if (window.chrome && chrome.extension &&
+              chrome.extension.getBackgroundPage &&
+              chrome.extension.getBackgroundPage() === window) {
+            chrome.tabs.create({ url: evt.data.download, active: false })
+          } else {
+            window.location = evt.data.download
+          }
 
           // Cleanup
           if (readableStream) {


### PR DESCRIPTION
On Google Chrome, Web Extensions work basically as HTTPS pages, with most of the same capabilities, so it is relatively easy to support them.

The only caveat is that the background page can not navigate, therefore the download triggering has to be done differently (I used [chrome.tabs.create](https://developer.chrome.com/extensions/tabs#method-create), since that is always available for the background page and it is only 1 line of code).

I have put together an example Web Extension to test this out. The steps to test it are as follow:
1) Download the extension from this link and extract it to some folder: https://texkiller.eu.org/StreamSaver/chrome-extension/StreamSaver.js-chrome-extension.zip
2) On Google Chrome navigate to [chrome://extensions](chrome://extensions)
3) Make sure the Developer mode is active
4) Click on Load unpacked and select the folder where the file manifest.json is
5) Upon being loaded, the extension should automatically start downloading the file 'web-extension-back.txt' - this file was downloaded from the background page of the extension
6) To test an extension page from a tab instead of the background page, click on the extension icon on the toolbar, and a tab should be opened
7) Upon being loaded, the test.html page should automatically start downloading the file 'web-extension-front.txt'

If you want to test the changes on a regular page to make sure it doesn't break anything, you can do so here:
https://texkiller.eu.org/StreamSaver/chrome-extension/

I have done all those tests on Google Chrome version 72.0.3626.81 (32 bits)