### PR TITLE
Ping sw from Shared Worker on HTTP pages on Firefox

### DIFF
--- a/ping.html
+++ b/ping.html
@@ -1,0 +1,12 @@
+<!--
+	ping.html is a second "man in the middle" to ping the ServiceWorker and keep it alive
+
+	This is meant to keep the Service Worker from timing out while the download happens,
+  but since we can't ping the Service Worker directly from here we use a Shared Worker
+  to do the pinging. The Shared Worker stays alive until this iframe is closed.
+-->
+<script>
+let ping = new SharedWorker('ping.js')
+
+window.onmessage = event => ping.port.postMessage(event.data)
+</script>

--- a/ping.js
+++ b/ping.js
@@ -1,0 +1,14 @@
+
+onconnect = function(e) {
+  let port = e.ports[0]
+
+  port.onmessage = function(e) {
+    if (e.data.ping) {
+      port.onmessage = null
+      let keepAlive = () => fetch(e.data.ping)
+      setInterval(keepAlive, 29E3)
+      keepAlive()
+    }
+  }
+
+}


### PR DESCRIPTION
Ok, so this one is a bit bigger than my previous PRs.

During my tests, I found that Chrome and Opera never kill the Service Worker, even on HTTP pages with the popup closed. However, Firefox does kill it after about 30 seconds.

I tried a bunch of different things (like Fetching or XMLHttpRequest'ing the ping URL from the HTTP page itself, from an iframe, trying to get a hold of the Service Worker from an iframe), but nothing worked until I tried to ping the Service Worker from inside a Shared Worker started from an iframe: that worked.

Maybe there is another way to ping the Service Worker from HTTP pages on Firefox (apart from keeping the popup open), but I couldn't find it yet. So, here is a PR that does what I described earlier, but only on HTTP pages on Firefox and only if Transferable Streams are not supported.

You can test the current behaviour of the library on this link: http://texkiller.eu.org/StreamSaver/http-timeout/github.html
The download fails after about 30 seconds on Firefox.

With this change applied, however, the download continues to completion (about 1 hour): http://texkiller.eu.org/StreamSaver/http-timeout/

The iframe will be created only once (just like what happens on HTTPS pages), but the popup will still be opened and closed once per download (hence, you still have to trigger each download from an user interaction). There may be a way to improve that, I may dig into it later.

This was all tested by me on Firefox v65.0 and on many versions of Chrome and Opera.