### PR TITLE
Send user-initiated cancel event from service worker back to streamsaver

### DIFF
--- a/StreamSaver.js
+++ b/StreamSaver.js
@@ -203,10 +203,9 @@
       }
 
       channel.port1.onmessage = evt => {
-        // Readable stream was cancelled by user
-        if (evt.data.userAborted) {
-          streamSaver.isUserAborted = true;
-        }
+        // Track whether readable stream was cancelled by user
+        streamSaver.isUserAborted = !!evt.data.userAborted;
+        
         // Service worker sent us a link that we should open.
         if (evt.data.download) {
           // Special treatment for popup...

--- a/StreamSaver.js
+++ b/StreamSaver.js
@@ -21,12 +21,12 @@
     : 'navigate'
 
   const streamSaver = {
-    isUserAborted,
     createWriteStream,
     WritableStream: window.WritableStream || ponyfill.WritableStream,
     supported: true,
     version: { full: '2.0.0', major: 2, minor: 0, dot: 0 },
-    mitm: 'https://eschaefer.github.io/StreamSaver.js/mitm.html?version=2.0.0'
+    mitm: 'https://eschaefer.github.io/StreamSaver.js/mitm.html?version=2.0.0',
+    isUserAborted,
   }
 
   /**
@@ -203,6 +203,7 @@
       }
 
       channel.port1.onmessage = evt => {
+        // Readable stream was cancelled by user
         if (evt.data.userAborted) {
           streamSaver.isUserAborted = true;
         }

--- a/StreamSaver.js
+++ b/StreamSaver.js
@@ -201,6 +201,9 @@
       }
 
       channel.port1.onmessage = evt => {
+        if (evt.data.userAborted) {
+          window.isUserAborted = true;
+        }
         // Service worker sent us a link that we should open.
         if (evt.data.download) {
           // Special treatment for popup...

--- a/StreamSaver.js
+++ b/StreamSaver.js
@@ -25,7 +25,7 @@
     WritableStream: window.WritableStream || ponyfill.WritableStream,
     supported: true,
     version: { full: '2.0.0', major: 2, minor: 0, dot: 0 },
-    mitm: 'https://eschaefer.github.io/StreamSaver.js/mitm.html?version=2.0.0',
+    mitm: 'https://jimmywarting.github.io/StreamSaver.js/mitm.html?version=2.0.0',
     isUserAborted,
   }
 

--- a/StreamSaver.js
+++ b/StreamSaver.js
@@ -21,6 +21,7 @@
     : 'navigate'
 
   const streamSaver = {
+    isUserAborted,
     createWriteStream,
     WritableStream: window.WritableStream || ponyfill.WritableStream,
     supported: true,
@@ -203,7 +204,7 @@
 
       channel.port1.onmessage = evt => {
         if (evt.data.userAborted) {
-          isUserAborted = true;
+          streamSaver.isUserAborted = true;
         }
         // Service worker sent us a link that we should open.
         if (evt.data.download) {
@@ -290,9 +291,6 @@
         channel.port1.close()
         channel.port2.close()
         channel = null
-      },
-      isAbortedByUser () {
-        return isUserAborted
       }
     }, opts.writableStrategy)
   }

--- a/StreamSaver.js
+++ b/StreamSaver.js
@@ -26,7 +26,7 @@
     WritableStream: window.WritableStream || ponyfill.WritableStream,
     supported: true,
     version: { full: '2.0.0', major: 2, minor: 0, dot: 0 },
-    mitm: 'https://jimmywarting.github.io/StreamSaver.js/mitm.html?version=2.0.0'
+    mitm: 'https://eschaefer.github.io/StreamSaver.js/mitm.html?version=2.0.0'
   }
 
   /**

--- a/StreamSaver.js
+++ b/StreamSaver.js
@@ -11,6 +11,7 @@
 
   let mitmTransporter = null
   let supportsTransferable = false
+  let isUserAborted = false
   const test = fn => { try { fn() } catch (e) {} }
   const ponyfill = window.WebStreamsPolyfill || {}
   const isSecureContext = window.isSecureContext
@@ -202,7 +203,7 @@
 
       channel.port1.onmessage = evt => {
         if (evt.data.userAborted) {
-          window.isUserAborted = true;
+          isUserAborted = true;
         }
         // Service worker sent us a link that we should open.
         if (evt.data.download) {
@@ -289,6 +290,9 @@
         channel.port1.close()
         channel.port2.close()
         channel = null
+      },
+      isAbortedByUser () {
+        return isUserAborted
       }
     }, opts.writableStrategy)
   }

--- a/sw.js
+++ b/sw.js
@@ -38,6 +38,7 @@ self.onmessage = event => {
       metadata[0] = evt.data.readableStream
     }
   } else {
+    port.postMessage({ userAborted: false })
     metadata[0] = createStream(port)
   }
 

--- a/sw.js
+++ b/sw.js
@@ -65,6 +65,7 @@ function createStream (port) {
     },
     cancel () {
       console.log('user aborted')
+      port.postMessage({ userAborted: true })
     }
   })
 }


### PR DESCRIPTION
This solved a missing piece for me, which is to stop the writeable stream if the readable stream is cancelled by the user, by dismissing the download dialog (in FF for example).

Here's how I use it:

```javascript
import streamSaver from 'streamsaver';

export const magicStreamSaver = readableStream => {
  const fileStream = streamSaver.createWriteStream('assets.zip');

  return new Promise(resolve => {
    // more optimized
    if (window.WritableStream && readableStream.pipeTo) {
      readableStream.pipeTo(fileStream).then(() => {
        console.log('done writing');

        resolve();
      });
    } else {
      window.writer = fileStream.getWriter();

      const reader = readableStream.getReader();

      const pump = async () => {
        while (true) {
          const { done, value } = await reader.read(); 

          if (streamSaver.isUserAborted) {
            break;
          }

          if (done) {
            break;
          }

          window.writer.write(value);
        }

        window.writer.close();
        resolve();
      };

      pump();
    }
  });
};
```