### PR TITLE
Ignore messages other than from iframe parent

### DIFF
--- a/mitm.html
+++ b/mitm.html
@@ -60,6 +60,11 @@ function registerWorker() {
 function onMessage (event) {
   let { data, ports, origin } = event
 
+  // Ignore messages other than from iframe parent (e.g. extensions)
+  if (event.source !== window.parent) {
+    return
+  }
+  
   // It's important to have a messageChannel, don't want to interfere
   // with other simultaneous downloads
   if (!ports || !ports.length) {


### PR DESCRIPTION
Malformed messages from extensions throw errors (though download still works). This filters out messages, except those coming from iframe parent.

To reproduce errors:
- Install MetaMask extension
- Open https://jimmywarting.github.io/StreamSaver.js/examples/fetch.html
- Click "Start" button
- See errors in browser console
```
Uncaught TypeError: [StreamSaver] You didn't send a messageChannel    at onMessage (mitm.html?version=2.0.0:66)
Uncaught TypeError: [StreamSaver] You didn't send a messageChannel    at onMessage (mitm.html?version=2.0.0:66)
Uncaught (in promise) TypeError: [StreamSaver] You didn't send a messageChannel    at onMessage (mitm.html?version=2.0.0:66)
Uncaught TypeError: [StreamSaver] You didn't send a messageChannel    at onMessage (mitm.html?version=2.0.0:66)
Uncaught TypeError: [StreamSaver] You didn't send a messageChannel    at onMessage (mitm.html?version=2.0.0:66)
```