### PR TITLE
Partially closes #13 on Firefox in order to prepare to Chrome future release

### DIFF
--- a/StreamSaver.js
+++ b/StreamSaver.js
@@ -237,6 +237,13 @@
             // We never remove this iframes b/c it can interrupt saving
             makeIframe(evt.data.download)
           }
+        } else if (evt.data.abort) {
+          chunks = []
+          channel.port1.postMessage('abort') //send back so controller is aborted
+          channel.port1.onmessage = null
+          channel.port1.close()
+          channel.port2.close()
+          channel = null
         }
       }
 

--- a/sw.js
+++ b/sw.js
@@ -63,8 +63,9 @@ function createStream (port) {
         controller.enqueue(data)
       }
     },
-    cancel () {
-      console.log('user aborted')
+    cancel (reason) {
+      console.log('user aborted', reason)
+      port.postMessage({ abort: true })
     }
   })
 }


### PR DESCRIPTION
Since #13 was reported, Chrome had an issue where https://github.com/jimmywarting/StreamSaver.js/blob/cd8e32a84f951541c5be183b2b409bd17dbb16cd/sw.js#L66 would not be fired, and I believe, because of that nothing was ever implemented on this handler although it was always called by Firefox.

Also, reported on #13, ticket was filled in for the chrome team ([ticket #638494](https://chromium-review.googlesource.com/c/chromium/src/+/3347484)) a few years ago and it got merged last week.

Testing on Canary version `99.0.4828.0`, cancellation event still not being triggered but worker seems to be killed on user cancellation causing stream saver to write to throw at `write()`. (more investigation on this behaviour is actually needed but it does not allow more writing on the main thread as expected).

Now, to make sure we do abort the operation at user cancellation on Firefox, that does not kill the worker but just closes the file descriptor and maintains the worker running without sending any signal to the main thread the proposed changes are implemented. 
