### PR TITLE
fix: Support large streams in Firefox

### DIFF
--- a/mitm.html
+++ b/mitm.html
@@ -157,10 +157,10 @@ if (navigator.serviceWorker) {
     window.onmessage = onMessage
     messages.forEach(window.onmessage)
   })
-} else {
-  // FF can ping sw with fetch from a secure hidden iframe
-  // shouldn't really be possible?
-  keepAlive()
 }
+
+// FF can ping sw with fetch from a secure hidden iframe
+// shouldn't really be possible?
+keepAlive()
 
 </script>


### PR DESCRIPTION
Thank you for this excellent library! This change appears to fix #292 and #290. I tested it out by running the `write-slowly.html` example. In my experience with this change, the stream is kept open for longer than 30 seconds. It appears to complete writing data successfully regardless of how long the stream is open for.

- fix #292
- fix #290