### PR TITLE
Fix file download in HTTP over non secure context

### DIFF
--- a/StreamSaver.js
+++ b/StreamSaver.js
@@ -93,7 +93,7 @@
   try {
     // We can't look for service worker since it may still work on http
     new Response(new ReadableStream())
-    if (isSecureContext && !('serviceWorker' in navigator)) {
+    if (!('serviceWorker' in navigator)) {
       useBlobFallback = true
     }
   } catch (err) {


### PR DESCRIPTION
Hello,

I want to propose this modification that solve a download problem in my usage in mode HTTP in non secure context.

By default, the following code works if hostname matches http://localhost:3000/ or https://mydomain.com:3000, but not if using http://mydomain.com:3000 or http://192.168.1.1:3000.

I'm using streamSaver with react and npm version 2.0.6, with this function.

```
export function fetchFile(url, opts, filename) {

    // Use https://developer.mozilla.org/en-US/docs/Web/API/FileSystemWritableFileStream in the future
    if(opts.streamSaverPath){
        streamSaver.mitm = opts.streamSaverPath + '/mitm.html';
        console.log("Using mitm: " + streamSaver.mitm);
    }

    return fetch(url, opts).then(response => {
        const totalSize = response.headers.get('Content-Length');
        console.log("File size is: " + totalSize);

        // If the WritableStream is not available (Firefox, Safari), take it from the ponyfill
        if (!window.WritableStream) {
            console.log("Using ponyfill WritableStream");
            streamSaver.WritableStream = WritableStream;
            window.WritableStream = WritableStream;
        }

        const fileStream = streamSaver.createWriteStream(filename, {size: totalSize});
        const readableStream = response.body;

        // More optimized (mainly available in Safari)
        if (readableStream.pipeTo) {
            console.log("Using pipeTo method");
            return readableStream.pipeTo(fileStream);
        }

        console.log("Using pump method");

        // Else we create manually the pipe
        const writer = fileStream.getWriter();

        const reader = readableStream.getReader();
        const pump = () => reader.read()
            .then(res =>
                res.done ? writer.close() : writer.write(res.value).then(pump)
            );

        return pump();
    });
}
```