### PR TITLE
Set iframe as credentialless to support COEP environments

### DIFF
--- a/StreamSaver.js
+++ b/StreamSaver.js
@@ -47,6 +47,7 @@
     iframe.loaded = false
     iframe.name = 'iframe'
     iframe.isIframe = true
+    iframe.credentialless = true
     iframe.postMessage = (...args) => iframe.contentWindow.postMessage(...args)
     iframe.addEventListener('load', () => {
       iframe.loaded = true


### PR DESCRIPTION
Hi. A small contribution that adds support for loading the `mitm.html` from GitHub pages (that does not use COEP), from COEP environments by setting the iframe as credentialless.

Fixes #313 (to be closed). Relates to #318 #213.

https://developer.chrome.com/blog/iframe-credentialless/

https://developer.mozilla.org/en-US/docs/Web/Security/IFrame_credentialless