### PR TITLE
add doctype to mitm.html

### DIFF
--- a/mitm.html
+++ b/mitm.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!--
 	mitm.html is the lite "man in the middle"
 


### PR DESCRIPTION
without this tag at least in firefox you get a warning about the [Quirks Mode](https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode?utm_source=mozilla&utm_medium=firefox-console-errors&utm_campaign=default)