### PR TITLE
Enhance Uint8Array judgment

### DIFF
--- a/StreamSaver.js
+++ b/StreamSaver.js
@@ -260,7 +260,7 @@
 
     return (!useBlobFallback && ts && ts.writable) || new streamSaver.WritableStream({
       write (chunk) {
-        if (!(chunk instanceof Uint8Array)) {
+        if (Object.prototype.toString.call(chunk) !== '[object Uint8Array]') {
           throw new TypeError('Can only write Uint8Arrays')
         }
         if (useBlobFallback) {


### PR DESCRIPTION
I hope to enhance the judgment of Uint8Array.

Avoid the following problems.
```ts
 console.log('Is chunk Uint8Array?', chunk instanceof Uint8Array) // expect  true
 console.log('Type of chunk:', Object.prototype.toString.call(chunk) === '[object Uint8Array]') // expect [object Uint8Array]
// Is chunk Uint8Array? true
// Type of chunk: true
// Is chunk Uint8Array? false
// Type of chunk: true
// Is chunk Uint8Array? false
// Type of chunk: true
// Is chunk Uint8Array? true
// Type of chunk: true
// Is chunk Uint8Array? true
// Type of chunk: true
```

Avoid problems caused by Uint8Array not being the same.