### PR TITLE
fix: address memory leak when using Blob for downloads

### DIFF
--- a/StreamSaver.js
+++ b/StreamSaver.js
@@ -294,10 +294,12 @@
       close () {
         if (useBlobFallback) {
           const blob = new Blob(chunks, { type: 'application/octet-stream; charset=utf-8' })
+		  chunks = []
           const link = document.createElement('a')
           link.href = URL.createObjectURL(blob)
           link.download = filename
           link.click()
+		  URL.revokeObjectURL(link.href)
         } else {
           channel.port1.postMessage('end')
         }


### PR DESCRIPTION
<!-- Thanks for contributing! ❤️ -->
ref: #353 

Memory is already copied when the Blob is created, so it's safe to release the `chunks`. when a download is triggered, it's safe to use `URL.revokeObjectURL`. if the browser needs the user to confirm the download for some reason, such as needing the user to confirm the download of a file that came from HTTP, the browser itself will hold a memory copy, so there's no need to worry about the side effect of releasing it. .